### PR TITLE
Add metadata persistence and CopyObject support for rclone

### DIFF
--- a/src/main/java/com/example/s3proxy/entity/UserFileEntity.java
+++ b/src/main/java/com/example/s3proxy/entity/UserFileEntity.java
@@ -1,8 +1,12 @@
 package com.example.s3proxy.entity;
 
 import com.example.s3proxy.util.Sha256Utils;
+import com.example.s3proxy.util.JsonMapConverter;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 @Entity
 @Table(name = "minio_user_files", 
@@ -38,11 +42,20 @@ public class UserFileEntity {
     
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "last_modified", nullable = false)
+    private LocalDateTime lastModified;
+
+    @Convert(converter = JsonMapConverter.class)
+    @Column(name = "metadata_json", columnDefinition = "TEXT")
+    private Map<String, String> metadata = new HashMap<>();
     
     public UserFileEntity() {
-        this.createdAt = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.lastModified = now;
     }
-    
+
     public UserFileEntity(String bucket, String key, FileEntity file) {
         this();
         this.bucket = bucket;
@@ -69,7 +82,27 @@ public class UserFileEntity {
     
     public FileEntity getFile() { return file; }
     public void setFile(FileEntity file) { this.file = file; }
-    
+
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getLastModified() { return lastModified; }
+    public void setLastModified(LocalDateTime lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    public Map<String, String> getMetadata() {
+        if (metadata == null || metadata.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(metadata);
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            this.metadata = new HashMap<>();
+        } else {
+            this.metadata = new HashMap<>(metadata);
+        }
+    }
 }

--- a/src/main/java/com/example/s3proxy/util/JsonMapConverter.java
+++ b/src/main/java/com/example/s3proxy/util/JsonMapConverter.java
@@ -1,0 +1,49 @@
+package com.example.s3proxy.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple JPA converter that stores arbitrary string maps as JSON payloads.
+ * <p>
+ * We use this for persisting user supplied S3 metadata (x-amz-meta-*) without
+ * creating an extra table. The converter stores {@code Map<String, String>}
+ * instances as JSON text in the database and vice versa.
+ */
+@Converter
+public class JsonMapConverter implements AttributeConverter<Map<String, String>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, String>> MAP_TYPE = new TypeReference<>() {};
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to serialize metadata map", e);
+        }
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new HashMap<>();
+        }
+        try {
+            return OBJECT_MAPPER.readValue(dbData, MAP_TYPE);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to deserialize metadata map", e);
+        }
+    }
+}

--- a/src/main/resources/db/migration/h2/V2__Add_metadata_columns.sql
+++ b/src/main/resources/db/migration/h2/V2__Add_metadata_columns.sql
@@ -1,0 +1,10 @@
+-- V2__Add_metadata_columns.sql
+-- Add metadata storage and last_modified timestamp for user files in H2 schema
+
+ALTER TABLE minio_user_files
+    ADD COLUMN metadata_json CLOB NULL;
+
+ALTER TABLE minio_user_files
+    ADD COLUMN last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE minio_user_files SET last_modified = created_at WHERE last_modified IS NULL;

--- a/src/main/resources/db/migration/mysql/V2__Add_metadata_columns.sql
+++ b/src/main/resources/db/migration/mysql/V2__Add_metadata_columns.sql
@@ -1,0 +1,9 @@
+-- V2__Add_metadata_columns.sql
+-- Add metadata storage and last_modified timestamp for user files to track S3 metadata
+
+ALTER TABLE minio_user_files
+    ADD COLUMN metadata_json TEXT NULL AFTER created_at,
+    ADD COLUMN last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER metadata_json;
+
+-- Backfill last_modified with the existing created_at values
+UPDATE minio_user_files SET last_modified = created_at WHERE last_modified IS NULL;

--- a/src/test/java/com/example/s3proxy/ObjectListingUnitTest.java
+++ b/src/test/java/com/example/s3proxy/ObjectListingUnitTest.java
@@ -76,12 +76,17 @@ public class ObjectListingUnitTest {
                 .build();
 
         // Test that the endpoint with proper authentication headers reaches our controller
-        // (even though MinIO connection will fail, it shows our endpoint is working)
+        // and returns a successful listing response from the proxy layer
         webTestClient.get()
                 .uri("/test-bucket")
                 .header("Authorization", "AWS4-HMAC-SHA256 Credential=minioadmin/20241226/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=dummy")
                 .header("x-amz-date", "20241226T000000Z")
                 .exchange()
-                .expectStatus().is5xxServerError(); // Expected since MinIO is not available but auth passed
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .value(body -> {
+                    assert body.contains("<ListBucketResult");
+                    assert body.contains("<Name>test-bucket</Name>");
+                });
     }
 }

--- a/src/test/java/com/example/s3proxy/service/DeduplicationServiceTest.java
+++ b/src/test/java/com/example/s3proxy/service/DeduplicationServiceTest.java
@@ -58,7 +58,7 @@ class DeduplicationServiceTest {
         when(userFileRepository.save(any(UserFileEntity.class))).thenReturn(new UserFileEntity());
         
         // Act
-        String etag = deduplicationService.putObject(bucket, key, data, contentType);
+        String etag = deduplicationService.putObject(bucket, key, data, contentType, java.util.Collections.emptyMap());
         
         // Assert
         assertEquals(expectedHash.substring(0, 16), etag);
@@ -99,7 +99,7 @@ class DeduplicationServiceTest {
         when(fileRepository.findById(1L)).thenReturn(Optional.of(refreshedFile), Optional.of(finalFile));
         
         // Act
-        String etag = deduplicationService.putObject(bucket, key, data, contentType);
+        String etag = deduplicationService.putObject(bucket, key, data, contentType, java.util.Collections.emptyMap());
         
         // Assert
         assertEquals(expectedHash.substring(0, 16), etag);


### PR DESCRIPTION
## Summary
- persist S3 user metadata and last-modified timestamps via a JSON converter and new Flyway migrations
- teach the deduplication service and controller to capture metadata headers, emit them on GET/HEAD, and implement CopyObject handling
- refresh unit/integration tests and add coverage for metadata copy flows exercised by rclone

## Testing
- mvn -q test *(fails: Testcontainers requires a Docker environment in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e6b0c0dc8332bbdf31502a593aaa